### PR TITLE
Character page can now sort correctly by character skill queue end

### DIFF
--- a/wizardskillfarm/templates/wizardskillfarm/characters.html
+++ b/wizardskillfarm/templates/wizardskillfarm/characters.html
@@ -39,7 +39,7 @@
                     {% if character.skill_queue_end is null %}
                     <td>No Skill Queue</td>
                     {% else %}
-                    <td>{{ character.skill_queue_end|date:'d-m-Y' }} {{ character.skill_queue_end|time:'H:i' }}</td>
+                    <td data-order="{{ character.skill_queue_end|date:'U' }}">{{ character.skill_queue_end|date:'d-m-Y' }} {{ character.skill_queue_end|time:'H:i' }}</td>
                     {% endif %}
                 </tr>
                 {% endfor %}
@@ -56,7 +56,11 @@
 <script>
     $(document).ready(function()
         {
-            $("#sortableTable").tablesorter();
+            $("#sortableTable").tablesorter(
+                {
+                    sortList: [[1,1]]
+                }
+            );
         }
     );
 </script>


### PR DESCRIPTION
## Description

Character page can now be correctly sorted by skill queue end date


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked my code and corrected any misspellings
